### PR TITLE
Flutter v1.15.0

### DIFF
--- a/lib/src/text_one_line.dart
+++ b/lib/src/text_one_line.dart
@@ -53,6 +53,9 @@ class TextOneLine extends StatelessWidget implements Text {
   @override
   final TextWidthBasis textWidthBasis;
 
+  @override
+  final TextHeightBehavior textHeightBehavior;
+
   const TextOneLine(
     this.data, {
     Key key,
@@ -64,6 +67,7 @@ class TextOneLine extends StatelessWidget implements Text {
     this.overflow = TextOverflow.ellipsis,
     this.textScaleFactor = 1.0,
     this.textWidthBasis = TextWidthBasis.parent,
+    this.textHeightBehavior = const TextHeightBehavior(),
   })  : assert(data != null),
         super(key: key);
 
@@ -254,6 +258,14 @@ class RenderParagraphX extends RenderBox
   }
 
   final TextPainter _textPainter;
+
+  @override
+  TextHeightBehavior get textHeightBehavior => _textPainter.textHeightBehavior;
+
+  @override
+  set textHeightBehavior(TextHeightBehavior value) {
+    _textPainter.textHeightBehavior = value;
+  }
 
   /// The text to display.
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: assorted_layout_widgets
 description: Assorted layout widgets that boldly go where no native Flutter widgets have gone before.
-version: 1.0.15
+version: 1.1.0
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/assorted_layout_widgets
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/marcglasberg/assorted_layout_widgets
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
+  flutter: ^1.15.0
 
 dependencies:
   matrix4_transform: ^1.1.3


### PR DESCRIPTION
Upgrading to Flutter 1.15.0 is breaks the `TextOneLine` Widget and prevents compilation.
flutter/flutter#48346

Since it is a breaking change I bumped the minor version as well.