### PR TITLE
Fix TextOneLine render error when used in intrinsic height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## [4.0.1] - 2021/03/22
+
+* Fixed usage of `TextOneLine` as child of an intrinsic size widget.
+
 ## [4.0.0] - 2020/11/10
 
 * Nullsafety.
-* `RowSuper` horizontal alignment now applied when there are no `RowSpacer`s 
-  and `MainAxisSize` is `max`. 
+* `RowSuper` horizontal alignment now applied when there are no `RowSpacer`s
+  and `MainAxisSize` is `max`.
 
 ## [3.0.1] - 2020/11/10
 

--- a/example/lib/main_text_one_line.dart
+++ b/example/lib/main_text_one_line.dart
@@ -1,0 +1,54 @@
+import 'package:assorted_layout_widgets/assorted_layout_widgets.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(MaterialApp(home: Demo()));
+
+class Demo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    //
+    return Scaffold(
+      appBar: AppBar(title: const Text('TextOneLine Example')),
+      key: UniqueKey(), // Forces restart on hot reload.
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            IntrinsicHeight(child: TextOneLine("ELLIPSIS", style: TextStyle(fontWeight: FontWeight.bold))),
+            SizedBox(height: 10),
+            IntrinsicWidth(child: TextOneLine("short: Lorem ipsum")),
+            SizedBox(height: 10),
+            IntrinsicWidth(child: IntrinsicHeight(child: TextOneLine("medium: Lorem ipsum dolor sit amet, consectetur adipiscing elit"))),
+            SizedBox(height: 10),
+            TextOneLine(
+                "long: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
+            SizedBox(height: 20),
+            //
+            TextOneLine("FADE", overflow: TextOverflow.fade, style: TextStyle(fontWeight: FontWeight.bold)),
+            SizedBox(height: 10),
+            TextOneLine("short: Lorem ipsum", overflow: TextOverflow.fade),
+            SizedBox(height: 10),
+            TextOneLine("medium: Lorem ipsum dolor sit amet, consectetur adipiscing elit", overflow: TextOverflow.fade),
+            SizedBox(height: 10),
+            TextOneLine(
+              "long: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+              overflow: TextOverflow.fade,
+            ),
+            SizedBox(height: 20),
+            //
+            TextOneLine("CLIP", overflow: TextOverflow.clip, style: TextStyle(fontWeight: FontWeight.bold)),
+            SizedBox(height: 10),
+            TextOneLine("short: Lorem ipsum", overflow: TextOverflow.clip),
+            SizedBox(height: 10),
+            TextOneLine("medium: Lorem ipsum dolor sit amet, consectetur adipiscing elit", overflow: TextOverflow.clip),
+            SizedBox(height: 10),
+            TextOneLine(
+              "long: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+              overflow: TextOverflow.clip,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/text_one_line.dart
+++ b/lib/src/text_one_line.dart
@@ -545,7 +545,7 @@ class RenderParagraphX extends RenderBox
       child = childAfter(child);
       childIndex += 1;
     }
-    _textPainter.setPlaceholderDimensions(placeholderDimensions as List<PlaceholderDimensions>?);
+    _textPainter.setPlaceholderDimensions(placeholderDimensions.cast());
   }
 
   void _computeChildrenWidthWithMinIntrinsics(double height) {
@@ -564,7 +564,7 @@ class RenderParagraphX extends RenderBox
       child = childAfter(child);
       childIndex += 1;
     }
-    _textPainter.setPlaceholderDimensions(placeholderDimensions as List<PlaceholderDimensions>?);
+    _textPainter.setPlaceholderDimensions(placeholderDimensions.cast());
   }
 
   void _computeChildrenHeightWithMinIntrinsics(double width) {
@@ -583,7 +583,7 @@ class RenderParagraphX extends RenderBox
       child = childAfter(child);
       childIndex += 1;
     }
-    _textPainter.setPlaceholderDimensions(placeholderDimensions as List<PlaceholderDimensions>?);
+    _textPainter.setPlaceholderDimensions(placeholderDimensions.cast());
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: assorted_layout_widgets
 description: Layout widgets that boldly go where no native Flutter widgets have gone before. ColumnSuper, RowSuper, FitHorizontally, Box, WrapSuper, TextOneLine, Delayed, Pad.
 
-version: 4.0.0
+version: 4.0.1
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/assorted_layout_widgets
 


### PR DESCRIPTION
Fixes #10 by using the list casting method instead of force-casting to the (wrong) non-nullable list of nullable PlaceholderDimensions.

Also adds a minimal example (which reproduced the bug before fixing).