### PR TITLE
Migrate away from deprecated strong mode options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,10 @@
 analyzer:
-  strong-mode:
-    # Will become the default once non-nullable types land
-    # https://github.com/dart-lang/sdk/issues/31410#issuecomment-510683629
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    # Analysis language modes, documented at:
+    # https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning


### PR DESCRIPTION
The old `strong-mode` options have been deprecated and are [set for removal](https://github.com/dart-lang/sdk/issues/50679). I've replaced them with similar, augmented [analysis language modes](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks).