### PR TITLE
Remove missing_return warning option from analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,8 +8,6 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
-    # treat missing returns as a warning (not a hint)
-    missing_return: warning
     # allow having TODOs in the code
     todo: ignore
 


### PR DESCRIPTION
The missing_return analysis option is removed from the Dart analyzer in https://dart-review.googlesource.com/c/sdk/+/346182

Since the option is removed, the analyzer issues a warning when it sees the option in this analysis_options file, and CI systems running the analyzer on this code report it as a test failure.

Removed the option from the analysis_options.yaml file.