### PR TITLE
Remove avoid_null_checks_in_equality_operators rule from lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -121,11 +121,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_js_rounded_ints.html
     # - avoid_js_rounded_ints
 
-    # Null checks aren't required in ==() operators
-    # pedantic: enabled
-    # https://dart-lang.github.io/linter/lints/avoid_null_checks_in_equality_operators.html
-    - avoid_null_checks_in_equality_operators
-
     # Good APIs don't use ambiguous boolean parameters. Instead use named parameters
     # https://dart-lang.github.io/linter/lints/avoid_positional_boolean_parameters.html
     # - avoid_positional_boolean_parameters


### PR DESCRIPTION
The Dart team introduced a new Warning called [`NON_NULLABLE_EQUALS_PARAMETER`](https://github.com/dart-lang/sdk/blob/bf2fba78e006ce4feac43e514c0b8f3ea9e9fbb8/pkg/analyzer/lib/src/error/codes.g.dart#L7104) a few releases ago. It warns when the parameter of an `operator ==` override has a nullable type:

> "The parameter type of '==' operators should be non-nullable."

That new warning, plus null safety, basically replace the [`avoid_null_checks_in_equality_operators`](https://dart.dev/tools/linter-rules/avoid_null_checks_in_equality_operators) lint rule. This rule reports doing any null-check work on a nullable parameter of an `operator ==` override.

As I found out when I [migrated the tests](https://github.com/dart-lang/sdk/blob/main/pkg/linter/test/rules/avoid_null_checks_in_equality_operators_test.dart) from the legacy framework, the rule is a bit non-sensical now because of the redundancy. Every test case either has a `WarningCode.NON_NULLABLE_EQUALS_PARAMETER`, if it features a nullable parameter, or it features another warning like `WarningCode.UNNECESSARY_NULL_COMPARISON_TRUE` or `StaticWarningCode.INVALID_NULL_AWARE_OPERATOR`, if the parameter is non-nullable and is compared to `null`.