### PR TITLE
Remove unsafe_html lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -794,10 +794,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/unrelated_type_equality_checks.html
     - unrelated_type_equality_checks
 
-    # Web only
-    # https://dart-lang.github.io/linter/lints/unsafe_html.html
-    - unsafe_html
-
     # Always use hex syntax Color(0x00000001), never Color(1)
     # https://dart-lang.github.io/linter/lints/use_full_hex_values_for_flutter_colors.html
     - use_full_hex_values_for_flutter_colors


### PR DESCRIPTION
The unsafe_html lint rule was not meant for external usage. It was implemented for internal usage, before there was a set of internal lint rules.

This rule is not maintained, and does not have any external design. It is also meant to be used with cannot-ignore and in a VCS where specific owners have rights to specific files. None of this applies to this repo. Additionally, the rule only helps with dart:html elements, which is a library that is not imported anywhere in this repository.

See also https://github.com/dart-lang/linter/issues/5001 and https://github.com/flutter/flutter/issues/157530