### PR TITLE
[cleanup] remove `prefer_equal_for_default_values`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -517,11 +517,6 @@ linter:
     # https://dart-lang.github.io/linter/lints/prefer_double_quotes.html
     # - prefer_double_quotes
 
-    # Prevent confusion with call-side when using named parameters
-    # pedantic: enabled
-    # https://dart-lang.github.io/linter/lints/prefer_equal_for_default_values.html
-    - prefer_equal_for_default_values
-
     # Single line methods + implementation makes it hard to write comments for that line.
     # Dense code isn't necessarily better code.
     # pedantic: disabled


### PR DESCRIPTION
Removed in Dart 3.0.

A recent change to the analyzer (https://github.com/dart-lang/sdk/commit/a9f288a810f96497b3df5fa5817a9316795f7abd) will start flagging this as an error, blocking the flutter roll:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8723903301146696273/+/u/Run_customer_testing_tests/stdout

/fyi @marcglasberg