### PR TITLE
[cleanup] remove `package_api_docs`

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -39,7 +39,6 @@ linter:
     - library_prefixes
     - no_duplicate_case_values
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation


### PR DESCRIPTION
Follow-up from https://github.com/marcglasberg/assorted_layout_widgets/pull/37 where I missed this (also) recently removed lint. It's breaking the customer tests and currently blocking a flutter roll. Sorry for the hassle!

/fyi @marcglasberg 