### PR TITLE
Adds ignore to `_deprecated` example method

### DIFF
--- a/example/lib/main_side_by_side.dart
+++ b/example/lib/main_side_by_side.dart
@@ -80,6 +80,7 @@ class Demo extends StatelessWidget {
     );
   }
 
+  // ignore: unused_element
   Widget _deprecated() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
We are working towards making the `analysis_options.yaml` file warn when the deprecated/removed version of a certain lint is lower than the current constraints (see https://dart-review.googlesource.com/c/sdk/+/448063 and https://github.com/dart-lang/sdk/issues/59869).

Some work was done at https://github.com/marcglasberg/assorted_layout_widgets/pull/37 to make this change land, but unfortunately, the work towards this got stale. Recently, I've picked it up again, and to land it, we have to bump the version of this project to allow Flutter rolls to pass. But we are encountering an issue with the `_deprecated` method under the tests being declared and never used.

The change in this PR only adds an ignore comment above its declaration (so it can still be declared there for the convenience of uncommenting the code above). We could also make it public, but I don't suppose this is a desired path.